### PR TITLE
Added option to disable internal information

### DIFF
--- a/logger.ts
+++ b/logger.ts
@@ -5,12 +5,17 @@ export class Logger {
 
     private static instance: any
 
-    public static async getInstance(minLevelForConsole = 'DEBUG', minLevelForFile = 'WARNING', fileName = "./warnings-errors.txt", pureInfo?: boolean) {
+    public static async getInstance(minLevelForConsole = 'DEBUG', minLevelForFile = 'WARNING', fileName = "./warnings-errors.txt", pureInfo?: boolean, disableInternalInfo?: boolean) {
         if (Logger.instance === undefined) {
-            log.info(`preparing a new logger \nminLevelForConsole: ${minLevelForConsole} \nminLevelForFile: ${minLevelForFile} \nfileName: ${fileName}`)
+            if (disableInternalInfo !== true) {
+                log.info(`preparing a new logger \nminLevelForConsole: ${minLevelForConsole} \nminLevelForFile: ${minLevelForFile} \nfileName: ${fileName}`)
+            }
             Logger.instance = await Logger.prepareLogger(minLevelForConsole, minLevelForFile, fileName, pureInfo)
         }
-        log.info(`delivering logger \nminLevelForConsole: ${minLevelForConsole} \nminLevelForFile: ${minLevelForFile} \nfileName: ${fileName}`)
+
+        if (disableInternalInfo !== true) {
+            log.info(`delivering logger \nminLevelForConsole: ${minLevelForConsole} \nminLevelForFile: ${minLevelForFile} \nfileName: ${fileName}`)
+        }
         return Logger.instance
     }
     private static async prepareLogger(minLevelForConsole: string, minLevelForFile: string, fileName: string, pureInfo?: boolean): Promise<any> {

--- a/usage-example.ts
+++ b/usage-example.ts
@@ -1,4 +1,4 @@
-import { Logger } from 'https://deno.land/x/log/mod.ts'
+import { Logger } from './mod.ts'
 
 const minLevelConsole = 'DEBUG' 
 const minLevelFile = 'WARNING' 
@@ -7,6 +7,8 @@ const fileName = "./warnings-errors.txt"
 
 const pure = true // leaving out e.g. the time info
 
+const disableInternalInfo = true // no internal info
+
 export const logger = await Logger.getInstance(minLevelConsole, minLevelFile, fileName, pure)
 
 logger.debug('example debug message')
@@ -14,3 +16,11 @@ logger.info('example info')
 logger.warning('example warning')
 logger.error('example error message')
 logger.critical('example critical message')
+
+export const loggerWithoutInternalInfos = await Logger.getInstance(minLevelConsole, minLevelFile, fileName, pure, disableInternalInfo)
+
+loggerWithoutInternalInfos.debug('example debug message')
+loggerWithoutInternalInfos.info('example info')
+loggerWithoutInternalInfos.warning('example warning')
+loggerWithoutInternalInfos.error('example error message')
+loggerWithoutInternalInfos.critical('example critical message')


### PR DESCRIPTION
Added the `disableInternalInfo` option to get rid of the "preparing a new logger" and "delivering logger" messages.